### PR TITLE
Detach fieldset when a matrix or taxonomy is deleted

### DIFF
--- a/app/Observers/MatrixObserver.php
+++ b/app/Observers/MatrixObserver.php
@@ -104,6 +104,17 @@ class MatrixObserver
     }
 
     /**
+     * Handle the matrix "deleting" event.
+     *
+     * @param \App\Models\Matrix $matrix
+     * @return void
+     */
+    public function deleting(Matrix $matrix)
+    {
+        $matrix->detachFieldset();
+    }
+
+    /**
      * Handle the matrix "deleted" event.
      *
      * @param  \App\Models\Matrix  $matrix

--- a/app/Observers/TaxonomyObserver.php
+++ b/app/Observers/TaxonomyObserver.php
@@ -81,6 +81,17 @@ class TaxonomyObserver
     }
 
     /**
+     * Handle the taxonomy "deleting" event.
+     *
+     * @param  \App\Models\Taxonomy  $taxonomy
+     * @return void
+     */
+    public function deleting(Taxonomy $taxonomy)
+    {
+        $taxonomy->detachFieldset();
+    }
+
+    /**
      * Handle the taxonomy "deleted" event.
      *
      * @param  \App\Models\Taxonomy  $taxonomy


### PR DESCRIPTION
Thanks for sending a pull request! Please fill out the sections below and then delete this comment.

What does this implement or fix? Explain your changes.
------------------------------------------------------
When deleting a taxonomy or matrix, the fieldset should be detached.

Does this close any currently open issues?
------------------------------------------
- #108 

- [x] If merged, please delete my branch.
