### PR TITLE
Proxy matrix values to the page instance

### DIFF
--- a/app/Http/Controllers/API/MatrixPageController.php
+++ b/app/Http/Controllers/API/MatrixPageController.php
@@ -37,7 +37,6 @@ class MatrixPageController extends Controller
      */
     public function show($matrix)
     {
-
         $matrix = Matrix::where('slug', $matrix)->firstOrFail();
         $page   = (new Page($matrix->handle))->get();
 

--- a/app/Services/Routers/PageRouter.php
+++ b/app/Services/Routers/PageRouter.php
@@ -13,25 +13,29 @@ namespace App\Services\Routers;
 
 use App\Models\Matrix;
 use Illuminate\Http\Request;
+use App\Services\Builders\Page;
 
 class PageRouter extends Router
 {
     public function handle(Request $request)
     {
-        $pages = Matrix::where('type', 'page')->get();
+        $matrices = Matrix::where('type', 'page')->get();
 
-        foreach ($pages as $page) {
-            $found = $this->matchRoute($page->route, $request);
+        foreach ($matrices as $matrix) {
+            $found = $this->matchRoute($matrix->route, $request);
 
-            if ($found === false or empty($page->template)) {
+            if ($found === false or empty($matrix->template)) {
                 continue 1;
             }
 
+            $page = (new Page($matrix->handle))->get();
+            
             $data = $this->bindRouteData($page->route, $request, [
-                'page' => $page,
+                'matrix' => $matrix,
+                'page'   => $page,
             ]);
 
-            return view($page->template, $data);
+            return view($matrix->template, $data);
         }
     }
 }

--- a/resources/stubs/matrix/page.stub
+++ b/resources/stubs/matrix/page.stub
@@ -25,6 +25,13 @@ class {class} extends Model
     protected $table = 'mx_{handle}';
 
     /**
+     * The accessors to append to the model's array form.
+     *
+     * @var array
+     */
+    protected $appends = ['name', 'handle', 'slug', 'fields'];
+
+    /**
      * Mass assignment protection.
      *
      * @var array
@@ -71,5 +78,35 @@ class {class} extends Model
     public function getFieldsAttribute()
     {
         return $this->matrix->fieldset->fields;
+    }
+
+    /**
+     * Proxy the name attribute from the owning matrix.
+     *
+     * @return string
+     */
+    public function getNameAttribute()
+    {
+        return $this->matrix->name;
+    }
+
+    /**
+     * Proxy the handle attribute from the owning matrix.
+     *
+     * @return string
+     */
+    public function getHandleAttribute()
+    {
+        return $this->matrix->handle;
+    }
+
+    /**
+     * Proxy the slug attribute from the owning matrix.
+     *
+     * @return string
+     */
+    public function getSlugAttribute()
+    {
+        return $this->matrix->slug;
     }
 }

--- a/tests/Feature/PageTest.php
+++ b/tests/Feature/PageTest.php
@@ -15,6 +15,7 @@ use App\Models\Matrix;
 use App\Models\Fieldset;
 use Facades\MatrixFactory;
 use Tests\Foundation\TestCase;
+use App\Services\Builders\Page;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class PageTest extends TestCase
@@ -38,5 +39,19 @@ class PageTest extends TestCase
 
         $response = $this->json('PATCH', '/api/pages/' . $page->id, $formData);
         $response->assertStatus(200);
+    }
+
+    /** @test */
+    public function name_handle_and_slug_values_are_proxied_from_the_owning_matrix()
+    {
+        $this->actingAs($this->admin, 'api');
+
+        $matrix = MatrixFactory::asPage()->withName('Example Page')->create();
+
+        $page = (new Page($matrix->handle))->get();
+
+        $this->assertEquals($page->name, 'Example Page');
+        $this->assertEquals($page->slug, 'example-page');
+        $this->assertEquals($page->handle, 'example_page');
     }
 }


### PR DESCRIPTION
What does this implement or fix? Explain your changes.
------------------------------------------------------
- Proxied the `name`, `handle`, and `slug` values from the owning matrix container to the page, so users can access `$page->name`, etc.
- Resolved the `$page` instance and bound it to the matching page request through the page router

Does this close any currently open issues?
------------------------------------------
- #156

- [x] If merged, please delete my branch.
