### PR TITLE
Properly encrypt password when new user is created

### DIFF
--- a/app/Http/Controllers/API/Users/UserController.php
+++ b/app/Http/Controllers/API/Users/UserController.php
@@ -70,6 +70,8 @@ class UserController extends Controller
 
         $attributes = $request->validate($rules);
 
+        $attributes['password'] = bcrypt($attributes['password']);
+
         $user = User::create($attributes);
 
         if (! empty($request->get('role'))) {


### PR DESCRIPTION
### What does this implement or fix?
Previously, newly created users (created through the API) had passwords stored unencrypted. This will now run the same encryption as the password update methods.

- [x] If merged, please delete my branch.