### PR TITLE
File upload directory assignment

### DIFF
--- a/app/Http/Controllers/API/FileController.php
+++ b/app/Http/Controllers/API/FileController.php
@@ -85,9 +85,8 @@ class FileController extends Controller
      * Persist a new resource in storage.
      * 
      * @param  \Illuminate\Http\Request  $request
-     * @param  integer|null  $directory
      */
-    public function store(Request $request, $directory = null)
+    public function store(Request $request)
     {
         $request->validate([
             'file'         => 'file',
@@ -95,11 +94,7 @@ class FileController extends Controller
         ]);
 
         $directory = $request->input('directory_id', null);
-
-        
-        if ($directory == 0) {
-            $directory = null;
-        }
+        $directory = $directory == 0 ? null : $directory;
 
         $upload    = $request->file('file');
         $extension = $upload->extension();

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,4 +1,4 @@
 {
-    "/js/gravity.js": "/js/gravity.js?id=09cebfb80713af48594b",
+    "/js/gravity.js": "/js/gravity.js?id=fc9e331f1671a8155c1a",
     "/css/gravity.css": "/css/gravity.css?id=575b730ae4be1394d160"
 }

--- a/resources/js/components/FileManager/FileUploader.vue
+++ b/resources/js/components/FileManager/FileUploader.vue
@@ -17,6 +17,7 @@
               @vdropzone-queue-complete="dzComplete"
               @vdropzone-file-added="addFileUpload"
               @vdropzone-files-added="startUpload"
+              @vdropzone-sending="dzPreSend"
               @vdropzone-total-upload-progress="updateProgress"
               @vdropzone-error="showError">
           </vue-dropzone>
@@ -55,18 +56,7 @@
       ...mapGetters({
             currentDirectory: 'filemanager/getCurrentDirectory',
             dropzoneVisible: 'filemanager/getDropzoneVisible',
-            parentDirectory: 'filemanager/getParentDirectory',
-            currentPage: 'filemanager/getCurrentPage',
-            directories: 'filemanager/getDirectories',
             fileUploads: 'filemanager/getFileUploads',
-            hasSelection: 'filemanager/hasSelection',
-            totalPages: 'filemanager/getTotalPages',
-            direction: 'filemanager/getDirection',
-            display: 'filemanager/getDisplay',
-            loading: 'filemanager/getLoading',
-            files: 'filemanager/getFiles',
-            sort: 'filemanager/getSort',
-            view: 'filemanager/getView',
       }),
       csrf() {
         let token = document.head.querySelector('meta[name="csrf-token"]')
@@ -82,22 +72,13 @@
     methods: {
       ...mapActions({
           fetchFilesAndDirectories: 'filemanager/fetchFilesAndDirectories',
-          clearDirectorySelection: 'filemanager/clearDirectorySelection',
           setUploadsMinimized: 'filemanager/setUploadsMinimized',
           setDropzoneVisible: 'filemanager/setDropzoneVisible',
-          clearFileSelection: 'filemanager/clearFileSelection',
           setUploadProgress: 'filemanager/setUploadProgress',
           setUploadsVisible: 'filemanager/setUploadsVisible',
-          toggleDirection: 'filemanager/toggleDirection',
-          setCurrentPage: 'filemanager/setCurrentPage',
           setFileUploads: 'filemanager/setFileUploads',
           addFileUpload: 'filemanager/addFileUpload',
-          setDirection: 'filemanager/setDirection',
-          setDisplay: 'filemanager/setDisplay',
-          toggleView: 'filemanager/toggleView',
-          setFiles: 'filemanager/setFiles',
           addFile: 'filemanager/addFile',
-          setSort: 'filemanager/setSort',
       }),
       openDZ() {
         document.querySelector('.dz-hidden-input').click()
@@ -105,7 +86,9 @@
       configureDZ() {
         let dz = this.$refs.dropzone_element
         dz.options.headers['X-CSRF-TOKEN'] = this.csrf
-        dz.options.headers['directory_id'] = this.currentDirectory
+      },
+      dzPreSend(file, xhr, formData) {
+        formData.append('directory_id', this.currentDirectory)
       },
       dzUploaded(response) {
         toast(response.name + ' uploaded', 'success')
@@ -116,7 +99,6 @@
       },
       startUpload(files) {
         let vm = this
-        vm.configureDZ()
         vm.showUploads()
         vm.setDropzoneVisible(false)
       },


### PR DESCRIPTION
### What does this implement or fix?
Resolves issue of not being able to upload a file within a directory. Files uploaded within a directory will correctly be assigned a `directory_id`.

### Does this close any currently open issues?
- resolves #260 

- [x] If merged, please delete my branch.
- [x] I have compiled my javascript/scss resources for production, because I don't like submitting hundreds of thousands of new lines of code.
