### PR TITLE
Change fontawesome icons for certain fieldtypes

### DIFF
--- a/app/Fieldtypes/DividerFieldtype.php
+++ b/app/Fieldtypes/DividerFieldtype.php
@@ -21,7 +21,7 @@ class DividerFieldtype extends Fieldtype
     /**
      * @var string
      */
-    public $icon = 'horizontal-rule';
+    public $icon = 'window-minimize';
 
     /**
      * @var string

--- a/app/Fieldtypes/EditorFieldtype.php
+++ b/app/Fieldtypes/EditorFieldtype.php
@@ -21,7 +21,7 @@ class EditorFieldtype extends Fieldtype
     /**
      * @var string
      */
-    public $icon = 'plus-hexagon';
+    public $icon = 'plus-square';
 
     /**
      * @var string

--- a/app/Fieldtypes/RedactorFieldtype.php
+++ b/app/Fieldtypes/RedactorFieldtype.php
@@ -21,7 +21,7 @@ class RedactorFieldtype extends Fieldtype
     /**
      * @var string
      */
-    public $icon = 'h1';
+    public $icon = 'text-height';
 
     /**
      * @var string

--- a/app/Fieldtypes/TextareaFieldtype.php
+++ b/app/Fieldtypes/TextareaFieldtype.php
@@ -21,7 +21,7 @@ class TextareaFieldtype extends Fieldtype
     /**
      * @var string
      */
-    public $icon = 'pencil';
+    public $icon = 'pencil-alt';
 
     /**
      * @var string


### PR DESCRIPTION
### What does this implement or fix?
Change some fieldtype icons that were still reference icons from the FontAwesome pro pack.

### Screenshots
![image](https://user-images.githubusercontent.com/7810450/72474031-d8350280-379c-11ea-8f31-8964875a090d.png)

