### PR TITLE
Remove name format regex from matrix entries

### DIFF
--- a/app/Http/Controllers/API/CollectionController.php
+++ b/app/Http/Controllers/API/CollectionController.php
@@ -55,7 +55,7 @@ class CollectionController extends Controller
         
         $relationships = [];
         $rules         = [
-            'name'   => 'sometimes|regex:/^[A-z]/i',
+            'name'   => 'sometimes',
             'slug'   => 'sometimes',
             'status' => 'required|boolean',
         ];


### PR DESCRIPTION
### What does this implement or fix?
Removes validation rule for matrix entries that requires the first character to be alphabetical. This was added when applying this rule to collections and taxonomies, but should only be applied to the models themselves (which save tangible model files with this naming restriction), and not for entries.

### Does this close any currently open issues?
- Resolves #293 

