### PR TITLE
Set fusion:install to run after create-project command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,11 +111,8 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
-        "post-root-package-install": [
-            "@php -r \"file_exists('.env') || copy('.env.example', '.env');\""
-        ],
         "post-create-project-cmd": [
-            "@php artisan key:generate --ansi"
+            "@php artisan fusion:install"
         ]
     },
     "config": {


### PR DESCRIPTION
### What does this implement or fix?
Set `fusion:install` to run after the composer `create-project` command

### Does this close any currently open issues?
N/A