### PR TITLE
Remove post script

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,9 +109,6 @@
         "post-autoload-dump": [
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
-        ],
-        "post-create-project-cmd": [
-            "@php artisan fusion:install"
         ]
     },
     "config": {


### PR DESCRIPTION
### What does this implement or fix?
Composer currently does not support post scripts that accept user input (tty support). The `fusion:install` has been removed for this reason as a post-script composer process. Support for this is coming in composer 2.0, so we can revisit this then.

### Does this close any currently open issues?
N/A